### PR TITLE
feature: advertising init

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,16 +232,17 @@ For running example project:
 | Prop                     | Description                                 | Type      |
 | ------------------------ | ------------------------------------------- | --------- |
 | **`mediaId`**            | The JW media id.                            | `Int`     |
-| **`file`**               | The url of the file to play.                | `String`  |
-| **`title`**              | The title of the track.                     | `String`  |
-| **`image`**              | The url of the player thumbnail.            | `String`  |
-| **`autostart`**          | Should the track auto start.                | `Boolean` |
 | **`time`**               | should the player seek to a certain second. | `Int`     |
+| **`adVmap`**             | The url of ads VMAP xml.                    | `String`  |
 | **`desc`**               | Description of the track.                   | `String`  |
+| **`file`**               | The url of the file to play.                | `String`  |
+| **`image`**              | The url of the player thumbnail.            | `String`  |
+| **`title`**              | The title of the track.                     | `String`  |
+| **`autostart`**          | Should the track auto start.                | `Boolean` |
 | **`controls`**           | Should the control buttons show.            | `Boolean` |
-| **`repeat`**             | Should the track repeat.                    | `Boolean` |
 | **`displayDescription`** | Should the player show the description.     | `Boolean` |
 | **`displayTitle`**       | Should the player show the title.           | `Boolean` |
+| **`repeat`**             | Should the track repeat.                    | `Boolean` |
 
 ## Available props
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,5 +47,6 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation 'com.longtailvideo.jwplayer:jwplayer-core:+'
     implementation 'com.longtailvideo.jwplayer:jwplayer-common:+'
+    implementation 'com.longtailvideo.jwplayer:jwplayer-ima:+'
 }
-  
+

--- a/android/src/main/java/com/appgoalz/rnjwplayer/RNJWPlayerView.java
+++ b/android/src/main/java/com/appgoalz/rnjwplayer/RNJWPlayerView.java
@@ -54,6 +54,7 @@ import com.longtailvideo.jwplayer.events.TimeEvent;
 import com.longtailvideo.jwplayer.events.listeners.AdvertisingEvents;
 import com.longtailvideo.jwplayer.events.listeners.VideoPlayerEvents;
 import com.longtailvideo.jwplayer.fullscreen.FullscreenHandler;
+import com.longtailvideo.jwplayer.media.ads.ImaVMAPAdvertising;
 import com.longtailvideo.jwplayer.media.playlists.PlaylistItem;
 
 import java.util.ArrayList;
@@ -97,6 +98,7 @@ public class RNJWPlayerView extends RelativeLayout implements VideoPlayerEvents.
     String desc = "";
     String mediaId = "";
     String customStyle;
+    String adVmap = "";
 
     Boolean autostart = true;
     Boolean controls = true;
@@ -493,6 +495,15 @@ public class RNJWPlayerView extends RelativeLayout implements VideoPlayerEvents.
                             autostart = playlistItem.getBoolean("autostart");
                         }
 
+                        if (playlistItem.hasKey("adVmap")) {
+                            adVmap = playlistItem.getString("adVmap");
+                        }
+
+                        List<PlaylistItem> playlist = new ArrayList<>();
+                        playlist.add(newPlayListItem);
+
+                        ImaVMAPAdvertising imaVMAPAdvertising = new ImaVMAPAdvertising(adVmap);
+
                         PlayerConfig playerConfig = new PlayerConfig.Builder()
                                 .skinConfig(skinConfig)
                                 .repeat(false)
@@ -502,6 +513,8 @@ public class RNJWPlayerView extends RelativeLayout implements VideoPlayerEvents.
                                 .displayDescription(true)
                                 .nextUpDisplay(true)
                                 .stretching(STRETCHING_UNIFORM)
+                                .playlist(playlist)
+                                .advertising(imaVMAPAdvertising)
                                 .build();
 
                         Context simpleContext = getNonBuggyContext(getReactContext(), getAppContext());

--- a/ios/RNJWPlayerNativeView.h
+++ b/ios/RNJWPlayerNativeView.h
@@ -34,6 +34,7 @@
 @property(nonatomic)CGRect initFrame;
 @property(nonatomic)BOOL userPaused;
 @property(nonatomic)BOOL wasInterrupted;
+@property(nonatomic, strong)NSString *adVmap;
 
 @property(nonatomic, copy)RCTBubblingEventBlock onBeforePlay;
 @property(nonatomic, copy)RCTBubblingEventBlock onPlay;

--- a/ios/RNJWPlayerNativeView.m
+++ b/ios/RNJWPlayerNativeView.m
@@ -174,6 +174,20 @@ NSString* const AudioInterruptionsEnded = @"AudioInterruptionsEnded";
     return self.player.config.file;
 }
 
+-(void)setAdVmap:(NSString *)adVmap
+{
+    if(adVmap != nil && adVmap.length > 0 && ![adVmap isEqualToString:_player.config.advertising.adVmap]) {
+        self.player.config.advertising = [JWAdConfig new];
+        self.player.config.advertising.client = JWAdClientGoogima;
+        self.player.config.advertising.adVmap = adVmap;
+    }
+}
+
+-(NSString *)adVmap
+{
+    return self.player.config.advertising.adVmap;
+}
+
 -(void)setMediaId:(NSString *)mediaId
 {
     if(mediaId != nil && mediaId.length > 0 && ![mediaId isEqualToString:_player.config.mediaId]) {
@@ -353,6 +367,13 @@ NSString* const AudioInterruptionsEnded = @"AudioInterruptionsEnded";
         id mediaId = playlistItem[@"mediaId"];
         if ((mediaId != nil) && (mediaId != (id)[NSNull null])) {
             config.mediaId = mediaId;
+        }
+        
+        id adVmap = playlistItem[@"adVmap"];
+        if ((adVmap != nil) && (adVmap != (id)[NSNull null])) {
+            config.advertising = [JWAdConfig new];
+            config.advertising.client = JWAdClientGoogima;
+            config.advertising.adVmap = adVmap;
         }
         
         id title = playlistItem[@"title"];


### PR DESCRIPTION
Fixes #18 

## Further Readings

### what is VMAP?
https://www.iab.com/wp-content/uploads/2015/06/VMAPv1_0.pdf

### what is VAST?
https://www.iab.com/wp-content/uploads/2015/06/VASTv3_0.pdf

### JWPlayer Advertising Documentations
Android: https://developer.jwplayer.com/jwplayer/docs/android-schedule-google-ima
iOS: https://developer.jwplayer.com/jwplayer/docs/ios-schedule-google-ima-ads


## To note

- [ ] test if not using VMAP xml (try using VAST xml)
- [ ] other advertisement manifest format?