### PR TITLE
Fixed crash where Activity instance becomes null before service unbind

### DIFF
--- a/android/src/main/java/com/appgoalz/rnjwplayer/RNJWPlayerView.java
+++ b/android/src/main/java/com/appgoalz/rnjwplayer/RNJWPlayerView.java
@@ -244,7 +244,7 @@ public class RNJWPlayerView extends RelativeLayout implements VideoPlayerEvents.
         return (Activity) getContext();
     }
 
-    public void destroyPlayer() {
+    public void destroyPlayer(Context applicationContext) {
         if (mPlayer != null) {
             mPlayer.stop();
 
@@ -284,7 +284,7 @@ public class RNJWPlayerView extends RelativeLayout implements VideoPlayerEvents.
             }
 
             audioManager = null;
-            doUnbindService();
+            doUnbindService(applicationContext);
         }
     }
 
@@ -672,10 +672,10 @@ public class RNJWPlayerView extends RelativeLayout implements VideoPlayerEvents.
 
     }
 
-    private void doUnbindService() {
+    private void doUnbindService(Context applicationContext) {
         if (mIsBound) {
             // Detach our existing connection.
-            mActivity.unbindService(mServiceConnection);
+            applicationContext.unbindService(mServiceConnection);
             mIsBound = false;
         }
     }

--- a/android/src/main/java/com/appgoalz/rnjwplayer/RNJWPlayerViewManager.java
+++ b/android/src/main/java/com/appgoalz/rnjwplayer/RNJWPlayerViewManager.java
@@ -373,7 +373,7 @@ public class RNJWPlayerViewManager extends SimpleViewManager<RNJWPlayerView> {
 
   @Override
   public void onDropViewInstance(@Nonnull RNJWPlayerView view) {
-    view.destroyPlayer();
+    view.destroyPlayer(mAppContext);
     view = null;
 
     super.onDropViewInstance(view);


### PR DESCRIPTION
Fixed issue that I encountered a lot in my production app.

The problem is that many devices keeps player in background playing. Then they probably trying to close the app from home screen. App tries to unbind service but the activity is NULL. This may be because of several reasons. For example app was in background for too long and Android OS shut down the activity.

StackTrace: https://prnt.sc/sclsk3
Additional data from crashlytics: https://prnt.sc/scludt