### PR TITLE
Alex/tako 895

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,25 +236,28 @@ For running example project:
 5. Add your iOS api key for JWPlayer into `Info.plist`
 
 ##### PlaylistItem
-| Prop                     | Description                                 | Type                            |
-| ------------------------ | ------------------------------------------- | ------------------------------- |
-| **`mediaId`**            | The JW media id.                            | `Int`                           |
-| **`time`**               | should the player seek to a certain second. | `Int`                           |
-| **`adVmap`**             | The url of ads VMAP xml.                    | `String`                        |
-| **`adSchedule`**         | Array of tags and and offsets for ads.      | `{tag: String, offset: String}` |
-| **`desc`**               | Description of the track.                   | `String`                        |
-| **`file`**               | The url of the file to play.                | `String`                        |
-| **`image`**              | The url of the player thumbnail.            | `String`                        |
-| **`title`**              | The title of the track.                     | `String`                        |
-| **`autostart`**          | Should the track auto start.                | `Boolean`                       |
-| **`controls`**           | Should the control buttons show.            | `Boolean`                       |
-| **`displayDescription`** | Should the player show the description.     | `Boolean`                       |
-| **`displayTitle`**       | Should the player show the title.           | `Boolean`                       |
-| **`repeat`**             | Should the track repeat.                    | `Boolean`                       |
+
+| Prop                      | Description                                                         | Type                            |
+| ------------------------- | ------------------------------------------------------------------- | ------------------------------- |
+| **`mediaId`**             | The JW media id.                                                    | `Int`                           |
+| **`time`**                | should the player seek to a certain second.                         | `Int`                           |
+| **`adVmap`**              | The url of ads VMAP xml.                                            | `String`                        |
+| **`adSchedule`**          | Array of tags and and offsets for ads.                              | `{tag: String, offset: String}` |
+| **`desc`**                | Description of the track.                                           | `String`                        |
+| **`file`**                | The url of the file to play.                                        | `String`                        |
+| **`image`**               | The url of the player thumbnail.                                    | `String`                        |
+| **`title`**               | The title of the track.                                             | `String`                        |
+| **`autostart`**           | Should the track auto start.                                        | `Boolean`                       |
+| **`controls`**            | Should the control buttons show.                                    | `Boolean`                       |
+| **`displayDescription`**  | Should the player show the description.                             | `Boolean`                       |
+| **`displayTitle`**        | Should the player show the title.                                   | `Boolean`                       |
+| **`repeat`**              | Should the track repeat.                                            | `Boolean`                       |
+| **`hideFromMediaCenter`** | `Available on Android` Should controls show up in the media center. | `Boolean`                       |
 
 ##### JWPlayerState
 
 #### **iOS**
+
 | State                        | Value |
 | ---------------------------- | ----- |
 | **`JWPlayerStatePlaying`**   | 0     |
@@ -265,6 +268,7 @@ For running example project:
 | **`JWPlayerStateError`**     | 5     |
 
 #### **Android**
+
 | State                        | Value |
 | ---------------------------- | ----- |
 | **`JWPlayerStateIdle`**      | 0     |
@@ -275,6 +279,7 @@ For running example project:
 | **`JWPlayerStateError`**     | null  |
 
 ## Available props
+
 | Prop                           | Description                                                                                                                                                            | Type                                                |
 | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
 | **`mediaId`**                  | The JW media id.                                                                                                                                                       | `Int`                                               |
@@ -296,6 +301,7 @@ For running example project:
 | **`nativeFullScreen`**         | When this is true the player will go into full screen on the native layer automatically without the need to manage the full screen request in js onFullScreen callback | `Boolean`                                           |
 | **`fullScreenOnLandscape`**    | When this is true the player will go into full screen on rotate of phone to landscape                                                                                  | `Boolean`                                           |
 | **`landscapeOnFullScreen`**    | When this is true the player will go into landscape orientation when on full screen                                                                                    | `Boolean`                                           |
+| **`enableBackgroundAudio`**    | `Available on Android.` Enable or disables background audio. Defaults to on                                                                                            | `Boolean`                                           |
 | **`portraitOnExitFullScreen`** | `Available on Android.` When this is true the player will go into portrait orientation when exiting full screen                                                        | `Boolean`                                           |
 | **`exitFullScreenOnPortrait`** | `Available on Android.` When this is true the player will exit full screen when the phone goes into portrait                                                           | `Boolean`                                           |
 

--- a/android/src/main/java/com/appgoalz/rnjwplayer/RNJWPlayerView.java
+++ b/android/src/main/java/com/appgoalz/rnjwplayer/RNJWPlayerView.java
@@ -138,6 +138,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     Boolean landscapeOnFullScreen = false;
     Boolean fullScreenOnLandscape = false;
     Boolean portraitOnExitFullScreen = false;
+    Boolean enableBackgroundAudio = true;
 
     ReadableMap playlistItem; // PlaylistItem
     ReadableArray playlist; // List <PlaylistItem>
@@ -503,7 +504,7 @@ public class RNJWPlayerView extends RelativeLayout implements
             });
 
             mPlayer.setControls(true);
-            mPlayer.setBackgroundAudio(true); // TODO: - add as prop
+            mPlayer.setBackgroundAudio(enableBackgroundAudio);
         }
     }
 
@@ -607,11 +608,14 @@ public class RNJWPlayerView extends RelativeLayout implements
 
                         setupPlayerView();
 
-                        NotificationManager notificationManager = (NotificationManager)mActivity.getSystemService(Context.NOTIFICATION_SERVICE);
-                        mNotificationWrapper = new NotificationWrapper(notificationManager);
-                        mMediaSessionManager = new MediaSessionManager(simpleContext,
-                                mPlayer,
-                                mNotificationWrapper);
+
+                        if (playlistItem.hasKey("hideFromMediaCenter")) {
+                            NotificationManager notificationManager = (NotificationManager)mActivity.getSystemService(Context.NOTIFICATION_SERVICE);
+                            mNotificationWrapper = new NotificationWrapper(notificationManager);
+                            mMediaSessionManager = new MediaSessionManager(simpleContext,
+                                    mPlayer,
+                                    mNotificationWrapper);
+                        }
 
                         if (playlistItem.hasKey("autostart")) {
                             mPlayer.getConfig().setAutostart(playlistItem.getBoolean("autostart"));

--- a/android/src/main/java/com/appgoalz/rnjwplayer/RNJWPlayerViewManager.java
+++ b/android/src/main/java/com/appgoalz/rnjwplayer/RNJWPlayerViewManager.java
@@ -227,6 +227,13 @@ public class RNJWPlayerViewManager extends SimpleViewManager<RNJWPlayerView> {
     }
   }
 
+  @ReactProp(name = "enableBackgroundAudio")
+  public void setEnableBackgroundAudio(RNJWPlayerView view, Boolean prop) {
+    if (prop != null) {
+      view.enableBackgroundAudio = prop;
+    }
+  }
+
   public Map getExportedCustomBubblingEventTypeConstants() {
     return MapBuilder.builder()
             .put(

--- a/index.js
+++ b/index.js
@@ -56,12 +56,13 @@ export default class JWPlayer extends Component {
       icons: PropTypes.string,
       timeslider: PropTypes.shape({
         progress: PropTypes.string,
-        rail: PropTypes.string
-      })
+        rail: PropTypes.string,
+      }),
     }),
     nativeFullScreen: PropTypes.bool,
     fullScreenOnLandscape: PropTypes.bool,
     landscapeOnFullScreen: PropTypes.bool,
+    enableBackgroundAudio: PropTypes.bool,
     portraitOnExitFullScreen: PropTypes.bool,
     exitFullScreenOnPortrait: PropTypes.bool,
     playlistItem: PropTypes.shape({


### PR DESCRIPTION
I had a few issues with media center on Android while in the background, so I added an `enableBackgroundAudio` prop to toggle background audio on and off as well as a new `playlistItem` prop called `hideFromMediaCenter` which will show or hide the controls in the android media center.