### PR TITLE
Fix build.grade for 0.1.49

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,5 +50,6 @@ dependencies {
     implementation 'com.longtailvideo.jwplayer:jwplayer-ima:+'
     implementation 'com.longtailvideo.jwplayer:jwplayer-chromecast:+'
     implementation 'androidx.mediarouter:mediarouter:1.1.0'
+    implementation 'androidx.media:media:1.1.0'
 }
 


### PR DESCRIPTION
Currently it's not working on 0.1.49 without this for android.