### PR TITLE
Fix issue in podspec with GoogleCast.framework 

### DIFF
--- a/ios/react-native-jw-media-player.podspec
+++ b/ios/react-native-jw-media-player.podspec
@@ -19,6 +19,8 @@ Pod::Spec.new do |s|
   s.dependency   'google-cast-sdk', '~> 4.4.5'
   s.dependency   'React'
   
+  s.static_framework = true
+  
   s.info_plist = {
     'NSBluetoothAlwaysUsageDescription' => 'We will use your Bluetooth for media casting.',
     'NSBluetoothPeripheralUsageDescription' => 'We will use your Bluetooth for media casting.',


### PR DESCRIPTION
Currently when the main project uses 'use_frameworks!' in the Podfile, when building it throws an error:
`The 'Pods-APP' target has transitive dependencies that include statically linked binaries: (/Users/user/APP/ios/Pods/google-cast-sdk/GoogleCastSDK-ios-4.4.8_static/GoogleCast.framework`
This allows for the build to work, tested.


