### PR TITLE
Fix: pipEnabled prop handle for android

### DIFF
--- a/android/src/main/java/com/appgoalz/rnjwplayer/RNJWPlayerView.java
+++ b/android/src/main/java/com/appgoalz/rnjwplayer/RNJWPlayerView.java
@@ -733,7 +733,12 @@ public class RNJWPlayerView extends RelativeLayout implements
         mPlayer.setup(playerConfig);
 
         if (mActivity != null && prop.hasKey("pipEnabled")) {
-            mPlayer.registerActivityForPip(mActivity, mActivity.getSupportActionBar());
+            boolean pipEnabled = prop.getBoolean("pipEnabled");
+            if(pipEnabled){
+                mPlayer.registerActivityForPip(mActivity, mActivity.getSupportActionBar());
+            }else{
+                mPlayer.deregisterActivityForPip();
+            }
         }
 
         if (mColors != null) {


### PR DESCRIPTION
Fix: Android enabled pip even is you set "pipEnabled: false"