### PR TITLE
IOS : Fixes an issue in how pipEnabled and backgroundAudioEnabled props are used

### DIFF
--- a/ios/RNJWPlayer/RNJWPlayerView.m
+++ b/ios/RNJWPlayer/RNJWPlayerView.m
@@ -113,8 +113,8 @@
     id license = config[@"license"];
     [self setLicense:license];
     
-    _backgroundAudioEnabled = config[@"backgroundAudioEnabled"];
-    _pipEnabled = config[@"pipEnabled"];
+    _backgroundAudioEnabled = [config[@"backgroundAudioEnabled"] boolValue];
+    _pipEnabled = [config[@"pipEnabled"] boolValue];
     if (_backgroundAudioEnabled || _pipEnabled) {
         id category = config[@"category"];
         id categoryOptions = config[@"categoryOptions"];


### PR DESCRIPTION
Even if i pass pipEnabled or backgroundAudioEnabled as false in React Native component props, here it was considering it as "true".

So sometimes unintended crash also used to happen in some scenarios. Also with pipEnabled, there were certain crashes happening on ios.