### PR TITLE
Ensure viewOnly can be optional in typescript to reflect iOS behaviour

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -153,7 +153,7 @@ declare module "react-native-jw-media-player" {
     processSpcUrl?: string;
     fairplayCertUrl?: string;
     contentUUID?: string;
-    viewOnly: boolean;
+    viewOnly?: boolean;
     enableLockScreenControls: boolean;
     pipEnabled: boolean;
   }


### PR DESCRIPTION
for iOS viewOnly has to be omitted (as per this https://github.com/chaimPaneth/react-native-jw-media-player/issues/198) however typescript complains as its a required property. This fixes that.