### PR TITLE
Android library fixes

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,6 +49,12 @@ allprojects {
 }
 
 dependencies {
+    // TODO: Remove after upgrade to React Native 0.68 or above
+    implementation ("androidx.appcompat:appcompat:1.3.1") {
+        version {
+            strictly '1.3.1'
+        }
+    }
     implementation 'com.facebook.react:react-native:+'
     implementation 'com.google.code.gson:gson:2.8.9'
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -20,14 +20,11 @@
         </receiver>
         <service
             android:name="com.jwplayer.pub.api.background.MediaService"
-            android:exported="false">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MEDIA_BUTTON" />
             </intent-filter>
         </service>
-        <meta-data
-            android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
-            android:value="com.appgoalz.rnjwplayer.CastOptionsProvider" />
     </application>
 
 </manifest>

--- a/android/src/main/java/com/appgoalz/rnjwplayer/RNJWPlayerView.java
+++ b/android/src/main/java/com/appgoalz/rnjwplayer/RNJWPlayerView.java
@@ -899,18 +899,6 @@ public class RNJWPlayerView extends RelativeLayout implements
                         }
                     }
                     break;
-                case AudioManager.AUDIOFOCUS_LOSS:
-                    mPlayer.pause();
-                    wasInterrupted = true;
-                    hasAudioFocus = false;
-                    break;
-                case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
-                    mPlayer.pause();
-                    wasInterrupted = true;
-                    break;
-                case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:
-                    setVolume(initVolume / 2);
-                    break;
             }
         }
     }
@@ -934,24 +922,6 @@ public class RNJWPlayerView extends RelativeLayout implements
                                 mPlayer.play();
                             }
                         }
-                        break;
-                    case AudioManager.AUDIOFOCUS_LOSS:
-                        mPlayer.pause();
-                        synchronized(focusLock) {
-                            wasInterrupted = true;
-                            playbackDelayed = false;
-                        }
-                        hasAudioFocus = false;
-                        break;
-                    case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
-                        mPlayer.pause();
-                        synchronized(focusLock) {
-                            wasInterrupted = true;
-                            playbackDelayed = false;
-                        }
-                        break;
-                    case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:
-                        setVolume(initVolume / 2);
                         break;
                 }
             } else {


### PR DESCRIPTION
Includes fixes for Android that are needed to make the library work with Obe Mobile app:
- removed google cast options provider to enable our custom handling
- added specific appcompat version to support RN version lower than 0.68
- removed logic which stopped video when different audio player starts to play (would pause player when FeedFM starts to play)