### PR TITLE
Fix crash on Android due to unsupported event type

### DIFF
--- a/android/src/main/java/com/appgoalz/rnjwplayer/RNJWPlayerView.java
+++ b/android/src/main/java/com/appgoalz/rnjwplayer/RNJWPlayerView.java
@@ -1255,7 +1255,7 @@ public class RNJWPlayerView extends RelativeLayout implements
         event.putString("device", castEvent.getDeviceName());
         event.putBoolean("active", castEvent.isActive());
         event.putBoolean("available", castEvent.isAvailable());
-        getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "onCasting", event);
+        getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topCasting", event);
     }
 
     // LifecycleEventListener


### PR DESCRIPTION
This PR replaces "onCasting" with "topCasting" in RNJWPlayerView.java as suggested in a comment on the issue [#164](https://github.com/chaimPaneth/react-native-jw-media-player/issues/164#issuecomment-1219320426).

After this fix, the casting works fine on Android devices.