### PR TITLE
fix: update types for adSchedule

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ declare module "react-native-jw-media-player" {
   }
   type ClientTypes = "vast" | "ima" | "ima_dai";
   interface Advertising {
-    adSchedule?: AdSchedule;
+    adSchedule?: AdSchedule[];
     adVmap?: string;
     tag?: string;
     openBrowserOnAdClick?: boolean;
@@ -42,7 +42,7 @@ declare module "react-native-jw-media-player" {
     title?: string;
     description?: string;
     mediaId?: string;
-    adSchedule?: AdSchedule;
+    adSchedule?: AdSchedule[];
     adVmap?: string;
     tracks?: Track[];
     recommendations?: string;


### PR DESCRIPTION
Updated the TypeScript definition types for `Advertising.adSchedule` and `PlaylistItem.adSchedule` to match the prop-types shape [here](https://github.com/chaimPaneth/react-native-jw-media-player/blob/a60d6a13ef302ad1fc83f18d64e9186f3a009ca9/index.js#L115-L120) and [here](https://github.com/chaimPaneth/react-native-jw-media-player/blob/a60d6a13ef302ad1fc83f18d64e9186f3a009ca9/index.js#L127-L132).