### PR TITLE
get audio tracks crash bugfix

### DIFF
--- a/android/src/main/java/com/appgoalz/rnjwplayer/RNJWPlayerModule.java
+++ b/android/src/main/java/com/appgoalz/rnjwplayer/RNJWPlayerModule.java
@@ -347,15 +347,17 @@ public class RNJWPlayerModule extends ReactContextBaseJavaModule {
           if (playerView != null && playerView.mPlayer != null) {
             List<AudioTrack> audioTrackList = playerView.mPlayer.getAudioTracks();
             WritableArray audioTracks = Arguments.createArray();
-            for (int i = 0; i < audioTrackList.size(); i++) {
-              WritableMap audioTrack = Arguments.createMap();
-              AudioTrack track = audioTrackList.get(i);
-              audioTrack.putString("name", track.getName());
-              audioTrack.putString("language", track.getLanguage());
-              audioTrack.putString("groupId", track.getGroupId());
-              audioTrack.putBoolean("defaultTrack", track.isDefaultTrack());
-              audioTrack.putBoolean("autoSelect", track.isAutoSelect());
-              audioTracks.pushMap(audioTrack);
+            if (audioTrackList != null) {
+              for (int i = 0; i < audioTrackList.size(); i++) {
+                WritableMap audioTrack = Arguments.createMap();
+                AudioTrack track = audioTrackList.get(i);
+                audioTrack.putString("name", track.getName());
+                audioTrack.putString("language", track.getLanguage());
+                audioTrack.putString("groupId", track.getGroupId());
+                audioTrack.putBoolean("defaultTrack", track.isDefaultTrack());
+                audioTrack.putBoolean("autoSelect", track.isAutoSelect());
+                audioTracks.pushMap(audioTrack);
+              }
             }
             promise.resolve(audioTracks);
           } else {


### PR DESCRIPTION
Hello, I'm using this package in a TVOS application, in older and slower TVs when accessing `getAudioTracks` function, it crashes the app with the following error (reported on appcenter):

```
com.appgoalz.rnjwplayer.RNJWPlayerModule$15.execute RNJWPlayerModule.java, line 350

java.lang.NullPointerException: Attempt to invoke interface method 'int java.util.List.size()' on a null object reference
```

sometimes the `audioTrackList` is null and it crashes the app.
changing the code like this fixed the problem.
now instead of crashing it returns an empty Array.