### PR TITLE
Fix/ios-chromecast

### DIFF
--- a/ios/RNJWPlayer/RNJWPlayerViewController.swift
+++ b/ios/RNJWPlayer/RNJWPlayerViewController.swift
@@ -512,6 +512,7 @@ class RNJWPlayerViewController : JWPlayerViewController, JWPlayerViewControllerD
     }
 
     override func castController(_ controller:JWCastController, connectedTo device: JWCastingDevice) {
+        super.castController(controller, connectedTo:device)
         let dict:NSMutableDictionary! = NSMutableDictionary()
 
         dict.setObject(device.name, forKey:"name" as NSCopying)
@@ -542,6 +543,7 @@ class RNJWPlayerViewController : JWPlayerViewController, JWPlayerViewControllerD
     }
 
     override func castController(_ controller: JWCastController, devicesAvailable devices:[JWCastingDevice]) {
+        super.castController(controller, devicesAvailable:devices)
         parentView?.availableDevices = devices
 
         var devicesInfo: [[String: Any]] = []


### PR DESCRIPTION
### This PR does:
- Fixes issue for iOS casting where media was not sent to receiver on initial connection

### Why this is necessary:
Intended to address this #350 issue

### Additional information:
A super call is expected when overriding `castController`. Alternatively, you may call `controller.cast()` if desired in place of the super call