### PR TITLE
Add missing "nil" handling for categoryOptions in RNJWPlayerView.swift

### DIFF
--- a/ios/RNJWPlayer/RNJWPlayerView.swift
+++ b/ios/RNJWPlayer/RNJWPlayerView.swift
@@ -1468,7 +1468,7 @@ class RNJWPlayerView : UIView, JWPlayerDelegate, JWPlayerStateDelegate, JWAdDele
         }
     }
 
-    func setCategory(categoryName:String!, categoryOptions:[String]!) {
+    func setCategory(categoryName:String!, categoryOptions:[String]?) {
         if (audioSession == nil) {
             audioSession = AVAudioSession.sharedInstance()
         }
@@ -1492,25 +1492,25 @@ class RNJWPlayerView : UIView, JWPlayerDelegate, JWPlayerStateDelegate, JWAdDele
 
         var options: AVAudioSession.CategoryOptions = []
         if(categoryOptions != nil){
-            if categoryOptions.contains("MixWithOthers") {
+            if categoryOptions!.contains("MixWithOthers") {
                 options.insert(.mixWithOthers)
             }
-            if categoryOptions.contains("DuckOthers") {
+            if categoryOptions!.contains("DuckOthers") {
                 options.insert(.duckOthers)
             }
-            if categoryOptions.contains("AllowBluetooth") {
+            if categoryOptions!.contains("AllowBluetooth") {
                 options.insert(.allowBluetooth)
             }
-            if categoryOptions.contains("InterruptSpokenAudioAndMix") {
+            if categoryOptions!.contains("InterruptSpokenAudioAndMix") {
                 options.insert(.interruptSpokenAudioAndMixWithOthers)
             }
-            if categoryOptions.contains("AllowBluetoothA2DP") {
+            if categoryOptions!.contains("AllowBluetoothA2DP") {
                 options.insert(.allowBluetoothA2DP)
             }
-            if categoryOptions.contains("AllowAirPlay") {
+            if categoryOptions!.contains("AllowAirPlay") {
                 options.insert(.allowAirPlay)
             }
-            if categoryOptions.contains("OverrideMutedMicrophone") {
+            if categoryOptions!.contains("OverrideMutedMicrophone") {
                 if #available(iOS 14.5, *) {
                     options.insert(.overrideMutedMicrophoneInterruption)
                 } else {

--- a/ios/RNJWPlayer/RNJWPlayerView.swift
+++ b/ios/RNJWPlayer/RNJWPlayerView.swift
@@ -1491,29 +1491,31 @@ class RNJWPlayerView : UIView, JWPlayerDelegate, JWPlayerStateDelegate, JWAdDele
         }
 
         var options: AVAudioSession.CategoryOptions = []
-        if categoryOptions.contains("MixWithOthers") {
-            options.insert(.mixWithOthers)
-        }
-        if categoryOptions.contains("DuckOthers") {
-            options.insert(.duckOthers)
-        }
-        if categoryOptions.contains("AllowBluetooth") {
-            options.insert(.allowBluetooth)
-        }
-        if categoryOptions.contains("InterruptSpokenAudioAndMix") {
-            options.insert(.interruptSpokenAudioAndMixWithOthers)
-        }
-        if categoryOptions.contains("AllowBluetoothA2DP") {
-            options.insert(.allowBluetoothA2DP)
-        }
-        if categoryOptions.contains("AllowAirPlay") {
-            options.insert(.allowAirPlay)
-        }
-        if categoryOptions.contains("OverrideMutedMicrophone") {
-            if #available(iOS 14.5, *) {
-                options.insert(.overrideMutedMicrophoneInterruption)
-            } else {
-                // Handle the case for earlier versions if needed
+        if(categoryOptions != nil){
+            if categoryOptions.contains("MixWithOthers") {
+                options.insert(.mixWithOthers)
+            }
+            if categoryOptions.contains("DuckOthers") {
+                options.insert(.duckOthers)
+            }
+            if categoryOptions.contains("AllowBluetooth") {
+                options.insert(.allowBluetooth)
+            }
+            if categoryOptions.contains("InterruptSpokenAudioAndMix") {
+                options.insert(.interruptSpokenAudioAndMixWithOthers)
+            }
+            if categoryOptions.contains("AllowBluetoothA2DP") {
+                options.insert(.allowBluetoothA2DP)
+            }
+            if categoryOptions.contains("AllowAirPlay") {
+                options.insert(.allowAirPlay)
+            }
+            if categoryOptions.contains("OverrideMutedMicrophone") {
+                if #available(iOS 14.5, *) {
+                    options.insert(.overrideMutedMicrophoneInterruption)
+                } else {
+                    // Handle the case for earlier versions if needed
+                }
             }
         }
         


### PR DESCRIPTION
In ios, jwplayer crashes saying categoryOptions is nil when running categoryOptions.contains this happens when category is not nil but categoryOptions is nil